### PR TITLE
Updating go.mod rwxrob/cmdtab from v0.2.3 to v0.4.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,4 +4,4 @@ go 1.16
 
 // replace github.com/rwxrob/cmdtab => /home/rwxrob/repos/github.com/rwxrob/cmdtab
 
-require github.com/rwxrob/cmdtab v0.2.3-alpha // indirect
+require github.com/rwxrob/cmdtab v0.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,1 @@
-github.com/rwxrob/cmdtab v0.2.3-alpha h1:Tv65fO58omffS4ivwBFO1/u8wKPbFXH/pdHsExzfJzw=
-github.com/rwxrob/cmdtab v0.2.3-alpha/go.mod h1:TWGCTFAm9NlO9mR6aUB5dltAhcVK1FTiCzF7WLXwGgQ=
+github.com/rwxrob/cmdtab v0.4.0/go.mod h1:TWGCTFAm9NlO9mR6aUB5dltAhcVK1FTiCzF7WLXwGgQ=


### PR DESCRIPTION
Updating the rwxrob/cmdtab module version from the v0.2.3-alpha to v0.4.0, as the keg project relies on conf-go.